### PR TITLE
Replace zttp with Guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,15 +8,17 @@
     "homepage": "https://github.com/rocketeers-app/rocketeers-api-client",
     "license": "MIT",
     "type": "library",
-    "authors": [{
-        "name": "Mark van Eijk",
-        "email": "mark@vaneijk.co",
-        "role": "Developer"
-    }],
+    "authors": [
+        {
+            "name": "Mark van Eijk",
+            "email": "mark@vaneijk.co",
+            "role": "Developer"
+        }
+    ],
     "require": {
         "php": "^7.0|^8.0",
-        "illuminate/support": "^5.8.0|^6.0.0|^7.0.0|^8.0.0",
-        "kitetail/zttp": "^0.6.0"
+        "guzzlehttp/guzzle": "^7.3",
+        "illuminate/support": "^5.8.0|^6.0.0|^7.0.0|^8.0.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0.0",
@@ -35,7 +37,6 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
-
     },
     "config": {
         "sort-packages": true

--- a/src/Rocketeers.php
+++ b/src/Rocketeers.php
@@ -2,9 +2,6 @@
 
 namespace Rocketeers;
 
-use Zttp\ConnectionException;
-use Zttp\Zttp;
-
 class Rocketeers
 {
     protected $client;
@@ -14,11 +11,12 @@ class Rocketeers
     {
         $this->baseUrl = 'https://rocketeers.app/api/v1';
 
-        $this->client = Zttp::withOptions([
+        $this->client = new \GuzzleHttp\Client([
             'verify' => false,
             'timeout' => 3,
-        ])->withHeaders([
-            'Authorization' => 'Bearer '.$token,
+            'headers' => [
+                'Authorization' => 'Bearer '. $token,
+            ]
         ]);
     }
 

--- a/src/Rocketeers.php
+++ b/src/Rocketeers.php
@@ -2,26 +2,27 @@
 
 namespace Rocketeers;
 
+use Illuminate\Support\Facades\Http;
+
 class Rocketeers
 {
     protected $client;
     protected $baseUrl;
+    protected $token;
 
     public function __construct($token)
     {
         $this->baseUrl = 'https://rocketeers.app/api/v1';
-
-        $this->client = new \GuzzleHttp\Client([
-            'verify' => false,
-            'timeout' => 3,
-            'headers' => [
-                'Authorization' => 'Bearer '. $token,
-            ]
-        ]);
+        $this->token = $token;
     }
 
     public function report(array $data)
     {
-        return $this->client->post($this->baseUrl.'/errors', $data);
+        return Http::timeout(3)
+            ->withoutVerifying()
+            ->withHeaders([
+                'Authorization' => 'Bearer ' . $this->token,
+            ])
+            ->post($this->baseUrl . '/errors', $data);
     }
 }


### PR DESCRIPTION
Deze PR vervangt de Zttp client met de normale (originele) Http client van Laravel. Zttp heeft GuzzleHttp gelocked op 6.x en geeft problemen in Slim en Site repositories.

Ik heb alleen de code gewijzigd en dit niet getest in de praktijk.

GuzzleHttp is nog steeds een requirement: https://laravel.com/docs/8.x/http-client#introduction